### PR TITLE
fix: FakeIP/sniff bug + Windows 进程管理重写 + 日志 UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flowz",
-  "version": "3.2.7",
+  "version": "3.2.9",
   "singboxVersion": "1.12.13",
   "description": "FlowZ - 简洁现代的跨平台代理客户端",
   "main": "dist/main/main/index.js",

--- a/src/main/ipc/handlers/log-handlers.ts
+++ b/src/main/ipc/handlers/log-handlers.ts
@@ -3,13 +3,14 @@
  * 处理日志相关的 IPC 请求
  */
 
-import { IpcMainInvokeEvent } from 'electron';
+import { IpcMainInvokeEvent, shell } from 'electron';
 import { IPC_CHANNELS } from '../../../shared/ipc-channels';
 import type { LogEntry, LogLevel } from '../../../shared/types';
 import { registerIpcHandler } from '../ipc-handler';
 import { LogManager } from '../../services/LogManager';
 import { ProxyManager } from '../../services/ProxyManager';
 import { broadcastEvent } from '../ipc-events';
+import { getLogsPath } from '../../utils/paths';
 
 /**
  * 注册日志管理相关的 IPC 处理器
@@ -39,6 +40,20 @@ export function registerLogHandlers(logManager: LogManager, proxyManager?: Proxy
     IPC_CHANNELS.LOGS_SET_LEVEL,
     async (_event: IpcMainInvokeEvent, args: { level: LogLevel }) => {
       logManager.setLogLevel(args.level);
+    }
+  );
+
+  // 打开日志文件
+  registerIpcHandler<void, void>(
+    IPC_CHANNELS.LOGS_OPEN_FOLDER,
+    async (_event: IpcMainInvokeEvent) => {
+      const path = require('path');
+      const logFile = path.join(getLogsPath(), 'app.log');
+      const result = await shell.openPath(logFile);
+      if (result) {
+        // 非空字符串表示打开失败
+        throw new Error(`打开日志文件失败: ${result}`);
+      }
     }
   );
 

--- a/src/main/services/AdminPrivilege.ts
+++ b/src/main/services/AdminPrivilege.ts
@@ -32,13 +32,18 @@ export function isRunningAsAdmin(): boolean {
 
 /**
  * Windows 管理员权限检测
- * 通过尝试访问需要管理员权限的注册表项来判断
+ * 通过 whoami /groups 检查是否包含管理员组 SID
  */
 function isWindowsAdmin(): boolean {
   try {
     const { execSync } = require('child_process');
-    execSync('net session', { stdio: 'ignore', windowsHide: true });
-    return true;
+    const result = execSync('whoami /groups', {
+      encoding: 'utf-8',
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    // S-1-16-12288 是 High Mandatory Level（管理员完整性级别）
+    return result.includes('S-1-16-12288');
   } catch {
     return false;
   }

--- a/src/main/services/ProxyManager.ts
+++ b/src/main/services/ProxyManager.ts
@@ -14,6 +14,7 @@ import { IPC_CHANNELS } from '../../shared/ipc-channels';
 import { resourceManager } from './ResourceManager';
 import { retry } from '../utils/retry';
 import { getUserDataPath } from '../utils/paths';
+import { isRunningAsAdmin } from './AdminPrivilege';
 
 /**
  * 私有 IP 地址段（CIDR 格式）
@@ -721,7 +722,10 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
             ? 'gvisor'
             : config.tunConfig?.stack || 'system',
         sniff: true,
-        sniff_override_destination: true,
+        // FakeIP 模式下不设置 sniff_override_destination：
+        // FakeIP 通过映射表反查域名，不依赖 sniff 识别目标地址。
+        // sniff_override_destination 是真实 IP 模式的配置，在 FakeIP 模式下会导致
+        // SSH、QUIC 等 sniff 不可靠的协议拿着 FakeIP 直接发出连接，必然失败。
         // 在系统路由层面排除本地地址，确保本地代理端口可访问
         route_exclude_address: ['127.0.0.0/8', '::1/128'],
       };
@@ -1536,6 +1540,17 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     }
 
     const pidToKill = this.singboxPid;
+
+    // 进程已不存在，直接清理
+    if (!this.isProcessAlive(pidToKill)) {
+      this.logToManager('info', `sing-box 进程 (PID: ${pidToKill}) 已不存在，跳过终止`);
+      try { require('fs').unlinkSync(this.getPidFilePath()); } catch { /* ignore */ }
+      this.cleanup();
+      this.emit('stopped');
+      this.sendEventToRenderer(IPC_CHANNELS.EVENT_PROXY_STOPPED, {});
+      return;
+    }
+
     this.logToManager('info', `正在停止 sing-box 进程 (PID: ${pidToKill})...`);
 
     return new Promise((resolve) => {
@@ -1601,16 +1616,15 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       return;
     }
 
-    const pidToKill = this.singboxPid;
-    this.logToManager('info', `正在停止 sing-box 进程 (PID: ${pidToKill})，需要管理员权限...`);
+    this.logToManager('info', '正在停止所有 sing-box 进程...');
 
-    // 策略：先尝试普通权限 taskkill，失败再用 UAC 提权，最后用 wmic 兜底
-    const killed = await this.tryKillWindowsProcess(pidToKill);
+    // 按进程名杀掉所有 sing-box.exe 实例（包括残留的）
+    // taskkill /IM 比按 PID 更可靠：不依赖 PID 文件，能清理残留进程
+    const killed = await this.killAllSingBoxOnWindows();
 
-    if (!killed && this.isProcessAlive(pidToKill)) {
-      this.logToManager('error', `无法终止 sing-box 进程 (PID: ${pidToKill})，进程仍在运行`);
-      // 不清理 PID 信息，让调用方知道停止失败
-      throw new Error(`无法终止 sing-box 进程 (PID: ${pidToKill})`);
+    if (!killed) {
+      this.logToManager('error', '无法终止 sing-box 进程，可能仍在运行');
+      throw new Error('无法终止 sing-box 进程');
     }
 
     this.logToManager('info', 'sing-box 进程已停止');
@@ -1631,70 +1645,94 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
   }
 
   /**
-   * 多策略尝试终止 Windows 进程
-   * 依次尝试：普通 taskkill → UAC 提权 taskkill → wmic 终止
-   * @returns 是否成功终止
+   * 终止所有 sing-box.exe 进程
+   * 使用 PowerShell cmdlet（Get-Process / Stop-Process），避免 tasklist/taskkill/wmic
+   * 在某些系统上的"关键错误"问题
    */
-  private async tryKillWindowsProcess(pid: number): Promise<boolean> {
+  private async killAllSingBoxOnWindows(): Promise<boolean> {
     const { execSync } = require('child_process');
 
-    // 策略 1：普通权限 taskkill（系统代理模式下的进程不需要提权）
-    try {
-      execSync(`taskkill /F /PID ${pid}`, {
-        windowsHide: true,
-        stdio: 'ignore',
-        timeout: 5000,
-      });
-      // 等待进程退出
-      if (await this.waitForProcessExit(pid, 3000)) {
-        this.logToManager('debug', `普通 taskkill 成功终止进程 ${pid}`);
-        return true;
+    // 检查是否还有 sing-box 进程
+    const hasSingBox = (): boolean => {
+      try {
+        const result = execSync(
+          'powershell -NoProfile -Command "@(Get-Process sing-box -ErrorAction SilentlyContinue).Count"',
+          {
+            encoding: 'utf-8',
+            windowsHide: true,
+            stdio: ['ignore', 'pipe', 'ignore'],
+            timeout: 5000,
+          }
+        );
+        const count = parseInt(result.trim(), 10);
+        return !isNaN(count) && count > 0;
+      } catch {
+        return false;
       }
-    } catch {
-      this.logToManager('debug', `普通 taskkill 无法终止进程 ${pid}，尝试提权...`);
+    };
+
+    if (!hasSingBox()) {
+      this.logToManager('debug', '没有 sing-box 进程在运行');
+      return true;
     }
 
-    // 策略 2：UAC 提权 taskkill
-    try {
-      const uacKilled = await this.killWithUAC(pid);
-      if (uacKilled && await this.waitForProcessExit(pid, 3000)) {
-        this.logToManager('debug', `UAC taskkill 成功终止进程 ${pid}`);
-        return true;
+    // 当前是 TUN 模式且 FlowZ 非管理员权限运行：
+    // sing-box 是 UAC 提权启动的，普通 Stop-Process 必然失败，直接走 UAC 提权
+    const isTunMode = this.currentConfig?.proxyModeType === 'tun';
+    const skipNormalKill = isTunMode && !isRunningAsAdmin();
+
+    if (!skipNormalKill) {
+      // 策略 1：Stop-Process -Force
+      try {
+        execSync(
+          'powershell -NoProfile -Command "Stop-Process -Name sing-box -Force -ErrorAction Stop"',
+          {
+            windowsHide: true,
+            stdio: 'pipe',
+            timeout: 5000,
+          }
+        );
+        this.logToManager('debug', 'Stop-Process 执行完毕');
+      } catch (e: any) {
+        this.logToManager('debug', `Stop-Process 失败: stderr="${e.stderr?.toString().trim()}" status=${e.status}`);
       }
-    } catch {
-      this.logToManager('debug', `UAC taskkill 无法终止进程 ${pid}，尝试 wmic...`);
+
+      for (let i = 0; i < 30; i++) {
+        if (!hasSingBox()) return true;
+        await new Promise((r) => setTimeout(r, 100));
+      }
     }
 
-    // 策略 3：wmic 终止（不需要 UAC 弹窗，某些情况下比 taskkill 更可靠）
+    // 策略 2：UAC 提权 Stop-Process（针对高完整性级别的进程）
     try {
-      execSync(`wmic process where "ProcessId=${pid}" call terminate`, {
-        windowsHide: true,
-        stdio: 'ignore',
-        timeout: 5000,
-      });
-      if (await this.waitForProcessExit(pid, 3000)) {
-        this.logToManager('debug', `wmic 成功终止进程 ${pid}`);
-        return true;
+      this.logToManager('info', '通过 UAC 提权终止 sing-box 进程');
+      const uacKilled = await this.killAllSingBoxWithUAC();
+      if (uacKilled) {
+        for (let i = 0; i < 30; i++) {
+          if (!hasSingBox()) return true;
+          await new Promise((r) => setTimeout(r, 100));
+        }
       }
-    } catch {
-      this.logToManager('debug', `wmic 也无法终止进程 ${pid}`);
+    } catch (e) {
+      this.logToManager('debug', `UAC Stop-Process 异常: ${e}`);
     }
 
-    // 所有策略都失败
-    return !this.isProcessAlive(pid);
+    return !hasSingBox();
   }
 
   /**
-   * 使用 UAC 提权执行 taskkill
+   * UAC 提权终止所有 sing-box 进程
    */
-  private killWithUAC(pid: number): Promise<boolean> {
+  private killAllSingBoxWithUAC(): Promise<boolean> {
     return new Promise((resolve) => {
-      const psScript = "Start-Process -FilePath 'taskkill' -ArgumentList '/F','/PID','" + pid.toString() + "' -Verb RunAs -Wait -WindowStyle Hidden";
+      // 通过 -Verb RunAs 启动一个新的 PowerShell 进程执行 Stop-Process
+      const psScript =
+        "Start-Process -FilePath 'powershell.exe' -ArgumentList '-NoProfile','-Command','Stop-Process -Name sing-box -Force' -Verb RunAs -Wait -WindowStyle Hidden";
 
       const killProcess = spawn('powershell.exe', [
         '-NoProfile',
         '-ExecutionPolicy', 'Bypass',
-        '-Command', psScript
+        '-Command', psScript,
       ], {
         windowsHide: true,
       });
@@ -1702,7 +1740,7 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       const timeout = setTimeout(() => {
         try { killProcess.kill(); } catch { /* ignore */ }
         resolve(false);
-      }, 15000); // UAC 对话框超时 15 秒
+      }, 15000);
 
       killProcess.on('exit', (code) => {
         clearTimeout(timeout);
@@ -1881,21 +1919,21 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
     const { execSync } = require('child_process');
 
     try {
-      // 使用 wmic 获取所有 sing-box.exe 进程的 PID
-      const result = execSync('wmic process where "name=\'sing-box.exe\'" get ProcessId /format:list', {
-        encoding: 'utf-8',
-        windowsHide: true,
-        stdio: ['ignore', 'pipe', 'ignore']
-      });
+      // 使用 PowerShell Get-Process 获取所有 sing-box 进程的 PID
+      // 避免 wmic 在某些系统上的"关键错误"
+      const result = execSync(
+        'powershell -NoProfile -Command "Get-Process sing-box -ErrorAction SilentlyContinue | ForEach-Object { $_.Id }"',
+        {
+          encoding: 'utf-8',
+          windowsHide: true,
+          stdio: ['ignore', 'pipe', 'ignore'],
+          timeout: 5000,
+        }
+      );
 
-      // 解析 PID 列表
-      const pidMatches = result.match(/ProcessId=(\d+)/g);
-      if (!pidMatches || pidMatches.length === 0) {
-        return;
-      }
-
-      let pidList = pidMatches
-        .map((m: string) => parseInt(m.replace('ProcessId=', ''), 10))
+      let pidList: number[] = result
+        .split(/\s+/)
+        .map((s: string) => parseInt(s.trim(), 10))
         .filter((p: number) => !isNaN(p) && p > 0);
 
       // 排除当前正在管理的进程
@@ -1910,20 +1948,33 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
 
       this.logToManager('warn', `发现 ${pidList.length} 个残留的 sing-box 进程，正在清理: ${pidList.join(', ')}`);
 
-      // 使用多策略逐个终止进程
-      for (const pid of pidList) {
-        const killed = await this.tryKillWindowsProcess(pid);
-        if (!killed) {
-          this.logToManager('warn', `无法终止残留进程 ${pid}`);
-        }
+      // 用一次 Stop-Process 批量终止（按 PID）
+      const pidArgs = pidList.join(',');
+      try {
+        execSync(
+          `powershell -NoProfile -Command "Stop-Process -Id ${pidArgs} -Force -ErrorAction SilentlyContinue"`,
+          {
+            windowsHide: true,
+            stdio: 'pipe',
+            timeout: 5000,
+          }
+        );
+      } catch (e: any) {
+        this.logToManager('debug', `批量 Stop-Process 失败: ${e.stderr?.toString().trim()}`);
+      }
+
+      // 还有残留就 UAC 提权再杀一次
+      const stillAlive = pidList.filter((p) => this.isProcessAlive(p));
+      if (stillAlive.length > 0) {
+        this.logToManager('warn', `${stillAlive.length} 个进程未被普通权限终止，尝试 UAC 提权`);
+        await this.killAllSingBoxWithUAC();
       }
 
       this.logToManager('info', '残留进程清理完成');
 
-      // 等待一小段时间让系统清理
       await new Promise((resolve) => setTimeout(resolve, 500));
     } catch {
-      // wmic 命令失败，可能没有残留进程
+      // 命令失败，可能没有残留进程
     }
   }
 
@@ -1938,18 +1989,20 @@ export class ProxyManager extends EventEmitter implements IProxyManager {
       const { execSync } = require('child_process');
       
       if (process.platform === 'win32') {
-        // Windows: 使用 tasklist 检测进程
-        // /FI "PID eq xxx" 过滤指定 PID，/NH 不显示表头
-        const result = execSync(`tasklist /FI "PID eq ${pid}" /NH`, { 
-          encoding: 'utf-8',
-          windowsHide: true,
-          stdio: ['ignore', 'pipe', 'ignore'],
-          timeout: 10000,
-        });
-        // 进程不存在时，中文 Windows 输出"信息: 没有运行的任务匹配指定标准"
-        // 英文 Windows 输出 "INFO: No tasks are running..."
-        // 统一判断：如果输出包含 PID 数字，说明进程存在
-        return result.includes(String(pid));
+        // Windows: 使用 PowerShell Get-Process 检测进程
+        // 避免 tasklist 在某些系统上的"关键错误"问题
+        const result = execSync(
+          `powershell -NoProfile -Command "if (Get-Process -Id ${pid} -ErrorAction SilentlyContinue) { 'alive' } else { 'dead' }"`,
+          {
+            encoding: 'utf-8',
+            windowsHide: true,
+            stdio: ['ignore', 'pipe', 'ignore'],
+            timeout: 10000,
+          }
+        );
+        const alive = result.trim() === 'alive';
+        this.logToManager('debug', `isProcessAlive pid=${pid} alive=${alive}`);
+        return alive;
       } else {
         // macOS/Linux: 使用 ps 检测进程
         const result = execSync(`ps -p ${pid} -o pid=`, { 

--- a/src/renderer/bridge/api-wrapper.ts
+++ b/src/renderer/bridge/api-wrapper.ts
@@ -210,6 +210,16 @@ export async function clearLogs(): Promise<ApiResponse<void>> {
   }
 }
 
+export async function openLogFolder(): Promise<ApiResponse<void>> {
+  try {
+    await api.logs.openFolder();
+    return { success: true };
+  } catch (error: any) {
+    ErrorHandler.handleApiError(error, '打开日志文件夹');
+    return { success: false, error: error?.message };
+  }
+}
+
 /**
  * Version Information APIs
  */

--- a/src/renderer/components/home/real-time-logs.tsx
+++ b/src/renderer/components/home/real-time-logs.tsx
@@ -3,23 +3,25 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useAppStore } from '@/store/app-store';
-import { Trash2, ArrowDown } from 'lucide-react';
-import { getLogs, clearLogs, addEventListener, removeEventListener } from '@/bridge/api-wrapper';
+import { Trash2, ArrowDown, ArrowDownToLine, FolderOpen } from 'lucide-react';
+import { getLogs, clearLogs, openLogFolder, addEventListener, removeEventListener } from '@/bridge/api-wrapper';
 import type { LogEntry } from '@/bridge/types';
 
 export function RealTimeLogs() {
   const [logs, setLogs] = useState<LogEntry[]>([]);
-  const [isAutoScroll, setIsAutoScroll] = useState(false); // 默认不自动滚动
-  const [isUserScrolling, setIsUserScrolling] = useState(false);
+  const [isAutoScroll, setIsAutoScroll] = useState(false);
+  const isAutoScrollRef = useRef(false);
   const scrollAreaRef = useRef<HTMLDivElement>(null);
-  const userScrollTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const connectionStatus = useAppStore((state) => state.connectionStatus);
 
-  // Load initial logs and set up real-time updates
+  const getScrollElement = useCallback((): HTMLElement | null => {
+    return scrollAreaRef.current?.querySelector('[data-radix-scroll-area-viewport]') ?? null;
+  }, []);
+
   useEffect(() => {
     const loadInitialLogs = async () => {
       try {
-        const response = await getLogs(50);
+        const response = await getLogs(500);
         if (response && response.success && response.data) {
           setLogs(response.data);
         }
@@ -28,104 +30,50 @@ export function RealTimeLogs() {
       }
     };
 
-    // Load initial logs
     loadInitialLogs();
 
-    // Set up real-time log listener
     const handleLogReceived = (logEntry: LogEntry) => {
-      setLogs((prev) => {
-        const updated = [...prev, logEntry];
-        // Keep only last 100 logs
-        return updated.slice(-100);
-      });
+      setLogs((prev) => [...prev, logEntry].slice(-500));
     };
 
     addEventListener('logReceived', handleLogReceived);
-
-    return () => {
-      removeEventListener('logReceived', handleLogReceived);
-    };
+    return () => removeEventListener('logReceived', handleLogReceived);
   }, []);
 
-  // 获取滚动元素
-  const getScrollElement = useCallback(() => {
-    return scrollAreaRef.current?.querySelector('[data-radix-scroll-area-viewport]') as HTMLElement | null;
-  }, []);
-
-  // 检查是否在底部
-  const checkIsAtBottom = useCallback((element: HTMLElement) => {
-    const threshold = 30; // 距离底部30px以内认为在底部
-    return element.scrollTop + element.clientHeight >= element.scrollHeight - threshold;
-  }, []);
-
-  // 监听滚动事件
+  // 新日志到来时，只有开启了自动滚动才滚到底部
   useEffect(() => {
-    const scrollElement = getScrollElement();
-    if (!scrollElement) return;
-
-    const handleScroll = () => {
-      // 标记用户正在滚动
-      setIsUserScrolling(true);
-
-      // 清除之前的超时
-      if (userScrollTimeoutRef.current) {
-        clearTimeout(userScrollTimeoutRef.current);
-      }
-
-      // 设置超时，滚动停止后更新状态
-      userScrollTimeoutRef.current = setTimeout(() => {
-        setIsUserScrolling(false);
-        // 检查是否滚动到底部
-        const atBottom = checkIsAtBottom(scrollElement);
-        setIsAutoScroll(atBottom);
-      }, 150);
-    };
-
-    scrollElement.addEventListener('scroll', handleScroll, { passive: true });
-
-    return () => {
-      scrollElement.removeEventListener('scroll', handleScroll);
-      if (userScrollTimeoutRef.current) {
-        clearTimeout(userScrollTimeoutRef.current);
-      }
-    };
-  }, [getScrollElement, checkIsAtBottom]);
-
-  // 只有在自动滚动模式且用户没有主动滚动时才自动滚动到底部
-  useEffect(() => {
-    if (isAutoScroll && !isUserScrolling) {
-      const scrollElement = getScrollElement();
-      if (scrollElement) {
-        scrollElement.scrollTop = scrollElement.scrollHeight;
-      }
+    if (isAutoScrollRef.current) {
+      const el = getScrollElement();
+      if (el) el.scrollTop = el.scrollHeight;
     }
-  }, [logs, isAutoScroll, isUserScrolling, getScrollElement]);
+  }, [logs, getScrollElement]);
+
+  const handleToggleAutoScroll = () => {
+    const next = !isAutoScrollRef.current;
+    isAutoScrollRef.current = next;
+    setIsAutoScroll(next);
+    if (next) {
+      const el = getScrollElement();
+      if (el) el.scrollTop = el.scrollHeight;
+    }
+  };
 
   const handleClearLogs = async () => {
     try {
       const success = await clearLogs();
-      if (success) {
-        setLogs([]);
-      }
-    } catch (error) {
-      console.error('Failed to clear logs:', error);
-      // Clear local logs anyway
+      if (success) setLogs([]);
+    } catch {
       setLogs([]);
     }
   };
 
   const getLevelColor = (level: LogEntry['level']) => {
     switch (level) {
-      case 'error':
-        return 'text-red-500';
-      case 'warn':
-        return 'text-yellow-500';
-      case 'info':
-        return 'text-blue-500';
-      case 'debug':
-        return 'text-gray-500';
-      default:
-        return 'text-foreground';
+      case 'error': return 'text-red-500';
+      case 'warn': return 'text-yellow-500';
+      case 'info': return 'text-blue-500';
+      case 'debug': return 'text-gray-500';
+      default: return 'text-foreground';
     }
   };
 
@@ -134,15 +82,34 @@ export function RealTimeLogs() {
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle>实时日志</CardTitle>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleClearLogs}
-            disabled={logs.length === 0}
-          >
-            <Trash2 className="h-4 w-4 mr-1" />
-            清空
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant={isAutoScroll ? 'default' : 'outline'}
+              size="sm"
+              onClick={handleToggleAutoScroll}
+            >
+              <ArrowDownToLine className="h-4 w-4 mr-1" />
+              {isAutoScroll ? '自动滚动开' : '自动滚动关'}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={openLogFolder}
+              title="用记事本打开 app.log 查看历史日志"
+            >
+              <FolderOpen className="h-4 w-4 mr-1" />
+              本地日志
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleClearLogs}
+              disabled={logs.length === 0}
+            >
+              <Trash2 className="h-4 w-4 mr-1" />
+              清空
+            </Button>
+          </div>
         </div>
       </CardHeader>
       <CardContent>
@@ -158,7 +125,6 @@ export function RealTimeLogs() {
             <div className="space-y-1 select-text cursor-text">
               {logs.map((log, index) => {
                 const timestamp = new Date(log.timestamp).toLocaleTimeString('zh-CN');
-
                 return (
                   <div key={index} className="text-xs font-mono select-text">
                     <span className="text-muted-foreground">[{timestamp}]</span>
@@ -173,28 +139,22 @@ export function RealTimeLogs() {
           )}
         </ScrollArea>
 
-        <div className="mt-2 flex items-center justify-between">
-          <span className="text-xs text-muted-foreground">
-            {isAutoScroll ? '自动滚动已开启' : '自动滚动已关闭（滚动到底部可开启）'}
-          </span>
-          {!isAutoScroll && (
+        {!isAutoScroll && (
+          <div className="mt-2 flex justify-end">
             <Button
               variant="ghost"
               size="sm"
               onClick={() => {
-                setIsAutoScroll(true);
-                const scrollElement = getScrollElement();
-                if (scrollElement) {
-                  scrollElement.scrollTop = scrollElement.scrollHeight;
-                }
+                const el = getScrollElement();
+                if (el) el.scrollTop = el.scrollHeight;
               }}
               className="text-xs h-7"
             >
               <ArrowDown className="h-3 w-3 mr-1" />
-              滚动到底部
+              跳到底部
             </Button>
-          )}
-        </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/renderer/ipc/api-client.ts
+++ b/src/renderer/ipc/api-client.ts
@@ -241,6 +241,13 @@ export const logsApi = {
   },
 
   /**
+   * 打开日志文件夹
+   */
+  async openFolder(): Promise<void> {
+    return ipcClient.invoke(IPC_CHANNELS.LOGS_OPEN_FOLDER);
+  },
+
+  /**
    * 监听日志接收事件
    */
   onReceived(listener: (log: LogEntry) => void): () => void {

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -37,6 +37,7 @@ export const IPC_CHANNELS = {
   LOGS_GET: 'logs:get',
   LOGS_CLEAR: 'logs:clear',
   LOGS_SET_LEVEL: 'logs:setLevel',
+  LOGS_OPEN_FOLDER: 'logs:openFolder',
 
   // 系统代理管理
   SYSTEM_PROXY_ENABLE: 'systemProxy:enable',


### PR DESCRIPTION
## 主要改动

### 1. FakeIP 模式下 sniff 不可靠协议失败的 bug
**问题：** SSH 拿到 198.18.0.x 直连失败，AWS QUIC `connection: open connection ... context deadline exceeded`。

**根因：** TUN inbound 配置了 `sniff_override_destination: true`，让 sing-box 通过嗅探数据包识别真实域名。SSH（服务端先发包）和 QUIC（UDP）的 sniff 都不可靠，sniff 失败后拿着 FakeIP 直接发出连接必然失败。

**修复：** TUN inbound 去掉 `sniff_override_destination`，让 sing-box 通过 FakeIP 映射表反查域名，这是 FakeIP 模式的正确工作方式。

### 2. Windows 进程管理重写
**问题：** 部分 Windows 系统上 `tasklist` / `taskkill` / `wmic` 命令报"关键错误"（WMI 仓库异常），导致：
- 无法检测进程存活
- 无法终止 sing-box 进程
- 残留进程清理失败

**修复：**
- 全面切换到 PowerShell cmdlet（`Get-Process` / `Stop-Process`）
- 按进程名 `sing-box` 杀掉所有实例，不依赖 PID 文件
- 普通权限 + TUN 模式下跳过普通 Stop-Process，直接走 UAC 提权
- 进程已不存在时直接清理状态，避免误报"无法终止"
- `AdminPrivilege.isWindowsAdmin` 改用 `whoami /groups` 检查完整性级别 SID（比 `net session` 更可靠）

### 3. 实时日志 UI
- 自动滚动改为按钮控制，默认关闭（之前依赖 ScrollArea 滚动事件检测在 Radix 异步渲染下失效）
- 显示数量从 100 提升到 500
- 新增"本地日志"按钮，点击后用系统默认程序打开 `app.log`（Windows 默认记事本）

## 测试
- TUN 模式 SSH / `git pull` 正常
- 管理员 / 普通权限下停止代理都能正常终止 sing-box
- 自动滚动按钮开关行为正确
